### PR TITLE
RF-22586 fixup docs

### DIFF
--- a/CHOCO_README.md
+++ b/CHOCO_README.md
@@ -1,6 +1,6 @@
 # rainforest-cli
 
-A command line interface to interact with [Rainforest QA](https://www.rainforestqa.com/). Source, and more documentation is [availble here](https://github.com/rainforestapp/rainforest-cli#basic-usage)
+A command line interface to interact with [Rainforest QA](https://www.rainforestqa.com/). Source and more documentation is [available here](https://github.com/rainforestapp/rainforest-cli#basic-usage)
 
 ## Global Options
 
@@ -16,7 +16,7 @@ A command line interface to interact with [Rainforest QA](https://www.rainforest
 - `--feature ID` - filter tests in a feature.
 - `--run-group ID` - run/filter based on a run group. When used with `run`, this trigger a run from the run group; it can't be used in conjunction with other test filters.
 - `--environment-id` - run your tests using this environment. Otherwise it will use your default environment
-- `--conflict OPTION` - use the `abort` option to abort any runs in progress in the same environment as your new run. use the `abort-all` option to abort all runs in progress.
+- `--conflict OPTION` - use the `abort` option to abort any runs in progress in the same environment as your new run. Use the `abort-all` option to abort all runs in progress.
 - `--bg` - creates a run in the background & exits immediately after. Cannot be used together with `--max-reruns`.
 - `--crowd [default|automation|automation_and_crowd|on_premise_crowd]`
 - `--wait RUN_ID` - wait for an existing run to finish instead of starting a new one, and exit with a non-0 code if the run fails. rainforest-cli will exit immediately if the run is already complete.
@@ -24,7 +24,7 @@ A command line interface to interact with [Rainforest QA](https://www.rainforest
 - `--custom-url` - specify the URL for the run to use when testing against an ephemeral environment. Temporary environments will be automatically deleted 72 hours after they were last used.
 - `--description "CI automatic run"` - add an arbitrary description for the run.
 - `--release "1a2b3d"` - add an ID to associate the run with a release. Commonly used values are commit SHAs, build IDs, branch names, etc.
-- `--junit-file` - Create a junit xml report file with the specified name. Must be run in foreground mode, or with the report command.
+- `--junit-file` - Create a JUnit XML report file with the specified name. Must be run in foreground mode, or with the report command.
 - `--import-variable-csv-file /path/to/csv/file.csv` - Use with `run` and `--import-variable-name` to upload new tabular variable values before your run to specify the path to your CSV file.
 - `--import-variable-name NAME` - Use with `run` and `--import-variable-csv-file` to upload new tabular variable values before your run to specify the name of your tabular variable.
 - `--single-use` - Use with `run` or `csv-upload` to flag your variable upload as `single-use`. See `--import-variable-csv-file` and `--import-variable-name` options as well.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 # 🍫 Rainforest CLI Chocolatey 🍫
 
-This repo is used to build a Chocolatey package for [rainforest-cli](/rainforestapp/rainforest-cli), and then push it to the community repo.
+This repo builds Chocolatey packages for [rainforest-cli](/rainforestapp/rainforest-cli) and pushes them to the [community repo](https://community.chocolatey.org/packages/rainforest-cli).
+
+It is driven by Github actions configured in `.github/workflows/chocolatey.yml`.


### PR DESCRIPTION
@ukd1 I made some minor edits to the docs.

I noticed that on the [Chocolately page for the CLI](https://community.chocolatey.org/packages/rainforest-cli) they are escaping <'s and >'s, so I maybe worth changing to fix those as well? But then I realized that 4000 chars is really short, so maybe we should revamp the `CHOCO_README.md` to just give some context + pointers (RF is a service that helps you test your website, signup for free here, see the documentation here, use `rainforest --help` to see all the options etc, etc) rather than provide any specifics on usage - what do you think?