### PR TITLE
Remove disallowed email from description

### DIFF
--- a/.github/workflows/chocolatey.yml
+++ b/.github/workflows/chocolatey.yml
@@ -1,6 +1,11 @@
 on:
-  - workflow_dispatch
-  - push
+  workflow_dispatch:
+    inputs:
+      version:
+        description: CLI version to push to Chocolatey, e.g. v3.0.0
+        required: false
+        default: latest
+  push:
 jobs:
   chocolatey:
     runs-on: windows-latest
@@ -16,7 +21,7 @@ jobs:
       -
         name: Build
         run: |
-          ruby main.rb
+          ruby main.rb ${{ inputs.version }}
       -
         name: Choco Pack
         run: |
@@ -29,7 +34,7 @@ jobs:
           choco push @(gci *.nupkg)[0] --key $env:CHOCO_API_KEY --source https://push.chocolatey.org/
         env:
           CHOCO_API_KEY: ${{ secrets.CHOCO_API_KEY }}
-      - 
+      -
         name: Save Choco pacakge
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/chocolatey.yml
+++ b/.github/workflows/chocolatey.yml
@@ -29,6 +29,7 @@ jobs:
           choco pack
       -
         name: Choco Push
+        if: github.ref_name == 'main'
         run: |
           cd rainforest-cli/
           choco push @(gci *.nupkg)[0] --key $env:CHOCO_API_KEY --source https://push.chocolatey.org/

--- a/CHOCO_README.md
+++ b/CHOCO_README.md
@@ -4,7 +4,7 @@ A command line interface to interact with [Rainforest QA](https://www.rainforest
 
 ## Global Options
 
-- `--token <your-rainforest-token>` - your API token if it's not set via the `RAINFOREST_API_TOKEN` environment variable
+- `--token [your-rainforest-token]` - your API token if it's not set via the `RAINFOREST_API_TOKEN` environment variable
 - `--skip-update` - Do not automatically check for CLI updates
 
 ## Options
@@ -29,7 +29,7 @@ A command line interface to interact with [Rainforest QA](https://www.rainforest
 - `--import-variable-name NAME` - Use with `run` and `--import-variable-csv-file` to upload new tabular variable values before your run to specify the name of your tabular variable.
 - `--single-use` - Use with `run` or `csv-upload` to flag your variable upload as `single-use`. See `--import-variable-csv-file` and `--import-variable-name` options as well.
 - `--disable-telemetry` stops the cli sharing information about which CI system you may be using, and where you host your git repo (i.e. your git remote). Rainforest uses this to better integrate with CI tooling, and code hosting companies, it is not sold or shared. Disabling this may affect your Rainforest experience.
-- `--max-reruns` - If set to a value > 0 and a test fails, the CLI will re-run failed tests a number of times before reporting failure. If `--junit-file <filename>` is also used, the JUnit reports of reruns will be saved under `<filename>.1`, `<filename>.2` etc.
+- `--max-reruns` - If set to a value greater than 0 and a test fails, the CLI will re-run failed tests a number of times before reporting failure. If `--junit-file [filename]` is also used, the JUnit reports of reruns will be saved under `[filename].1`, `[filename].2` etc.
 
 ## Support
 

--- a/CHOCO_README.md
+++ b/CHOCO_README.md
@@ -33,4 +33,4 @@ A command line interface to interact with [Rainforest QA](https://www.rainforest
 
 ## Support
 
-Email [help@rainforestqa.com](mailto:help@rainforestqa.com) if you're having trouble using the CLI or need help with integrating Rainforest in your CI or development workflow.
+Email `help[at]rainforestqa.com` if you're having trouble using the CLI or need help with integrating Rainforest in your CI or development workflow.

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2021 Rainforest QA, Inc
+Copyright (c) 2022 Rainforest QA, Inc
 
 MIT License
 

--- a/main.rb
+++ b/main.rb
@@ -145,7 +145,7 @@ xml = builder.package(xmlns: 'http://schemas.microsoft.com/packaging/2015/06/nus
     metadata.authors('https://github.com/rainforestapp/rainforest-cli/graphs/contributors')
     metadata.projectUrl('https://www.rainforestqa.com')
     metadata.iconUrl('https://assets.website-files.com/60da68c37e57671c365004bd/60da68c37e576749595005ae_favicon-large.svg')
-    metadata.copyright('2021 Rainforest QA, Inc')
+    metadata.copyright("#{Time.now.year} Rainforest QA, Inc")
 
     metadata.licenseUrl('https://github.com/rainforestapp/rainforest-cli/blob/master/LICENSE.txt')
     metadata.requireLicenseAcceptance(true)

--- a/main.rb
+++ b/main.rb
@@ -4,15 +4,13 @@ require 'json'
 require 'fileutils'
 
 raise "CHOCO_README.md is too long. Limit is 4000 chars for choco pacakges. 🤷‍♂️" if File.read('CHOCO_README.md').to_s.length > 4000
+version = ARGV[0] || 'latest'
+version = "tags/#{version}" unless version == 'latest'
 
-res = HTTParty.get('https://api.github.com/repos/rainforestapp/rainforest-cli/releases')
-raise StandardError, "🚨 Error #{res.code} while fetching releases:\n#{res.body}" unless res.code == 200
+res = HTTParty.get("https://api.github.com/repos/rainforestapp/rainforest-cli/releases/#{version}")
+raise StandardError, "🚨 Error #{res.code} while fetching release:\n#{res.body}" unless res.code == 200
 
-releases = JSON.parse(res.body)
-
-latest_release = releases.find do |release|
-  !release['draft'] && !release['prerelease']
-end
+latest_release = JSON.parse(res.body)
 
 
 class Release

--- a/main.rb
+++ b/main.rb
@@ -139,7 +139,6 @@ xml = builder.package(xmlns: 'http://schemas.microsoft.com/packaging/2015/06/nus
     metadata.version(latest_release.version)
     metadata.summary('A command line interface to interact with Rainforest QA - https://www.rainforestqa.com/.')
     metadata.tags('rainforest-cli rainforest')
-    metadata.owners('@ukd1')
 
     metadata.packageSourceUrl('https://github.com/rainforestapp/rainforest-cli-chocolatey')
     metadata.authors('https://github.com/rainforestapp/rainforest-cli/graphs/contributors')

--- a/main.rb
+++ b/main.rb
@@ -10,7 +10,7 @@ version = "tags/#{version}" unless version == 'latest'
 res = HTTParty.get("https://api.github.com/repos/rainforestapp/rainforest-cli/releases/#{version}")
 raise StandardError, "🚨 Error #{res.code} while fetching release:\n#{res.body}" unless res.code == 200
 
-latest_release = JSON.parse(res.body)
+release = JSON.parse(res.body)
 
 
 class Release
@@ -62,17 +62,17 @@ def get_checksum(asset_name)
   end.split("  ")[0]
 end
 
-latest_release = Release.new(latest_release)
+release = Release.new(release)
 
-puts "Building 🍫 Chocolatey package for #{latest_release.version}"
+puts "Building 🍫 Chocolatey package for #{release.version}"
 
-unless File.exists?(File.basename(latest_release.windows_amd64['browser_download_url']))
+unless File.exists?(File.basename(release.windows_amd64['browser_download_url']))
   print "- Fetching release checksums "
-  latest_release.download(latest_release.checksums)
+  release.download(release.checksums)
   puts "✅"
 
-  print "- Fetching #{latest_release.windows_amd64_zip_name} "
-  latest_release.download(latest_release.windows_amd64, get_checksum(latest_release.windows_amd64_zip_name))
+  print "- Fetching #{release.windows_amd64_zip_name} "
+  release.download(release.windows_amd64, get_checksum(release.windows_amd64_zip_name))
   puts "✅"
 else
   puts "- Using cached archive - should only see this in dev 🧐"
@@ -86,8 +86,8 @@ FileUtils.mkdir_p('tmp')
 FileUtils.mkdir_p(File.join('rainforest-cli', 'tools'))
 puts "✅"
 
-print "- Unzipping #{latest_release.windows_amd64_zip_name} "
-`unzip -n #{latest_release.windows_amd64_zip_name} -d tmp`
+print "- Unzipping #{release.windows_amd64_zip_name} "
+`unzip -n #{release.windows_amd64_zip_name} -d tmp`
 puts "✅"
 
 print "- Moving exe --> package "
@@ -138,7 +138,7 @@ xml = builder.package(xmlns: 'http://schemas.microsoft.com/packaging/2015/06/nus
   package.metadata do |metadata|
     metadata.title('Rainforest CLI')
     metadata.id('rainforest-cli')
-    metadata.version(latest_release.version)
+    metadata.version(release.version)
     metadata.summary('A command line interface to interact with Rainforest QA - https://www.rainforestqa.com/.')
     metadata.tags('rainforest-cli rainforest')
 
@@ -154,7 +154,7 @@ xml = builder.package(xmlns: 'http://schemas.microsoft.com/packaging/2015/06/nus
     metadata.docsUrl('https://github.com/rainforestapp/rainforest-cli/blob/master/README.md')
     metadata.bugTrackerUrl('https://github.com/rainforestapp/rainforest-cli/issues')
     metadata.description(File.read('CHOCO_README.md').to_s)
-    metadata.releaseNotes(latest_release.notes)
+    metadata.releaseNotes(release.notes)
   end
 
   package.files do |files|

--- a/main.rb
+++ b/main.rb
@@ -26,6 +26,10 @@ class Release
     @release['tag_name'][1..-1]
   end
 
+  def notes
+    @release['body']
+  end
+
   def windows_amd64_zip_name
     "rainforest-cli-#{version}-windows-amd64.zip"
   end
@@ -152,7 +156,7 @@ xml = builder.package(xmlns: 'http://schemas.microsoft.com/packaging/2015/06/nus
     metadata.docsUrl('https://github.com/rainforestapp/rainforest-cli/blob/master/README.md')
     metadata.bugTrackerUrl('https://github.com/rainforestapp/rainforest-cli/issues')
     metadata.description(File.read('CHOCO_README.md').to_s)
-    # metadata.releaseNotes(File.read('../CHANGELOG.md').to_s[0..3999])
+    metadata.releaseNotes(latest_release.notes)
   end
 
   package.files do |files|


### PR DESCRIPTION
Chocolatey does not let us include emails in any text field of the `.nuspec` file. For whatever reason, this used to work, but our builds started getting flagged with `v3.0.0`, so neither `v3.0.0` nor `v3.1.0` have been published.