### PR TITLE
Don't `choco push` on `git push`

### DIFF
--- a/.github/workflows/chocolatey.yml
+++ b/.github/workflows/chocolatey.yml
@@ -5,7 +5,6 @@ on:
         description: CLI version to push to Chocolatey, e.g. v3.0.0
         required: false
         default: latest
-  push:
 jobs:
   chocolatey:
     runs-on: windows-latest
@@ -29,7 +28,6 @@ jobs:
           choco pack
       -
         name: Choco Push
-        if: github.ref_name == 'main'
         run: |
           cd rainforest-cli/
           choco push @(gci *.nupkg)[0] --key $env:CHOCO_API_KEY --source https://push.chocolatey.org/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,23 @@
+on: push
+
+jobs:
+  test:
+    runs-on: windows-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v3
+      -
+        name: Install deps
+        run: |
+          gem install bundler
+          bundle install
+      -
+        name: Build
+        run: |
+          ruby main.rb ${{ inputs.version }}
+      -
+        name: Choco Pack
+        run: |
+          cd rainforest-cli/
+          choco pack

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,6 @@
-source 'https://rubygems.org' do
-  gem 'builder', '~> 3.2', '>= 3.2.2'
-  gem 'httparty'
-end
+# frozen_string_literal: true
+
+source 'https://rubygems.org'
+
+gem 'builder', '~> 3.2', '>= 3.2.2'
+gem 'httparty'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,8 +14,8 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  builder (~> 3.2, >= 3.2.2)!
-  httparty!
+  builder (~> 3.2, >= 3.2.2)
+  httparty
 
 BUNDLED WITH
-   2.1.4
+   2.2.32


### PR DESCRIPTION
Testing that `main.rb` does its job makes sense, but we only want to `choco push` when releasing a new CLI version (i.e. via `workflow_dispatch`).