### PR TITLE
Replace deprecated/removed method with equivalent

### DIFF
--- a/main.rb
+++ b/main.rb
@@ -66,7 +66,7 @@ release = Release.new(release)
 
 puts "Building 🍫 Chocolatey package for #{release.version}"
 
-unless File.exists?(File.basename(release.windows_amd64['browser_download_url']))
+unless File.exist?(File.basename(release.windows_amd64['browser_download_url']))
   print "- Fetching release checksums "
   release.download(release.checksums)
   puts "✅"
@@ -100,7 +100,7 @@ FileUtils.cp(File.join('LICENSE'), File.join('rainforest-cli', 'tools', 'LICENSE
 puts "✅"
 
 exe = File.join(Dir.pwd, 'rainforest-cli', 'tools', 'rainforest.exe')
-if File.exists?(exe)
+if File.exist?(exe)
   cmd = "md5sum #{exe}"
   print "- Checksumming exe with '#{cmd}' "
   exe_checksum = `#{cmd}`


### PR DESCRIPTION
Ruby 3.2 removed `File.exists?` https://github.com/ruby/ruby/pull/5352 So replace it with `File.exist?`

![image](https://github.com/user-attachments/assets/fa678e67-7a3e-4ab6-b144-97063e753e5f)
